### PR TITLE
[Feat/nginx-domain] 🐛 fix : nginx 뒤에서 HTTPS 인식을 위한 설정 추가

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -32,6 +32,9 @@ DEBUG = env.bool("DJANGO_DEBUG", default=False)
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "localhost"])
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])
 
+# nginx 뒤에서 HTTPS 인식을 위한 설정
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # ──────────────────────────────────────────────────────────────────────
 # 앱
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: nginx 뒤에서 HTTPS 인식을 위한 설정 추가

