### PR TITLE
[Feat/gomoku-game] 🐛 fix : 금수 알림 이후에 착수가 불가능한 점 수정

### DIFF
--- a/templates/games/room.html
+++ b/templates/games/room.html
@@ -653,6 +653,8 @@
       // 돌 카운트도 리셋
       prevStoneCount = 0;
     } else if (m.type === "error") {
+      // 착수 에러 발생 시 플래그 해제 (다음 착수 가능하도록)
+      isPlaying = false;
       alert(m.message);
     } else if (m.type === "game_deleted") {
       // 게임이 삭제되었으므로 로비로 이동


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #26 
- 작업 요약: 금수 에러 발생 시 isPlaying 플래그가 해제되지 않아 다음 착수가 불가능 했던 점 수정

## 📄 상세 내용
- [X] 착수 에러 발생 시 다음 착수가 가능하도록 isPlaying = false; 
