### PR TITLE
[Feat/gomoku-game] 🐛 fix : 상대방 메시지도 입력한 텍스트 길이에 맞게 표시

### DIFF
--- a/templates/games/lobby.html
+++ b/templates/games/lobby.html
@@ -368,6 +368,8 @@
       border: 1px solid var(--line);
       font-size: 14px;
       word-wrap: break-word;
+      max-width: 240px;
+      width: fit-content;
     }
 
     .chat-message.mine .sender {


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #26 
- 작업 요약: 상대방 메시지도 입력한 텍스트 길이에 맞게 chat-message 옵션 추가
