### PR TITLE
[Feat/gomoku-game] 🐛 fix : 준비완료 모달창 중복 처리 수정, 마지막 착수 표기 수정

### DIFF
--- a/templates/games/room.html
+++ b/templates/games/room.html
@@ -765,6 +765,10 @@
   let isRoomCreator = false;  // 현재 유저가 방장(흑)인지 여부
 
   function showReadyModal() {
+    // 이미 표시되어 있으면 중복 방지
+    if (readyModal.style.display === "flex") return;
+
+    readyModalShown = true;  // 플래그 설정
     readyModal.style.display = "flex";
     // 초기 상태: 모두 준비 대기중
     readyBlackStatus.textContent = "준비 대기중...";


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #26 
- 작업 요약: 마지막 착수 표기 수정, 준비완료 모달창 중복 처리 수정

## 📄 상세 내용
- [X] 새로운 돌이 놓임 → lastStoneIndex 업데이트 (1회만!), render 함수가 다시 호출되어도 lastStoneIndex는 유지, 
매번 렌더링 시 해당 돌에 .last-move 클래스 추가, CSS 애니메이션은 3번만 재생 (4.5초) 후 자동 종료
- [X] readyModalShown = true를 함수 내에서 설정하여 render 함수에서 재호출 방지
