### PR TITLE
[Feat/gomoku-game] 🐛 fix : annotate를 사용하려고 했는데, UserProfile 모델에 이미 total_games가 @property로 정의되어 있어서 충돌 발생 해결

### DIFF
--- a/app/games/views.py
+++ b/app/games/views.py
@@ -2,7 +2,7 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import F, Q
+from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 
 from accounts.models import UserProfile


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: annotate를 사용하려고 했는데, UserProfile 모델에 이미 total_games가 @property로 정의되어 있어서 충돌 발생 해결
## 📄 상세 내용
- [X] annotate 대신 객체를 가져온 후 property(total_games, win_rate)를 직접 사용

