### PR TITLE
🐛 fix : 승률 랭킹 승수로 정렬 -> 승률로 정렬

### DIFF
--- a/app/games/views.py
+++ b/app/games/views.py
@@ -24,9 +24,7 @@ def lobby(request):
     # 랭킹 데이터 - 승률 기준 (최소 5판 이상)
     # 승률은 property라서 DB에서 정렬 불가 -> Python에서 정렬
     ranking_by_winrate_raw = (
-        UserProfile.objects.filter(wins__gt=0)
-        .select_related("user")
-        .all()
+        UserProfile.objects.filter(wins__gt=0).select_related("user").all()
     )
 
     # 최소 5판 이상인 프로필만 필터링하고 승률로 정렬


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 승률 랭킹 승수로 정렬 -> 승률로 정렬

## 📄 상세 내용
- [x] view에서 모든 프로필 가져오기 -> 최소 5판 이상 필터링 -> 승률로 정렬 (승률 같으면 총 게임 수 많은 순) -> 상위 10명만 선택하고 순위 부여



