### PR TITLE
[Feat/gomoku-refactoring] ♻️ refactor : 중복된 코드 유틸 함수와 헬퍼 메서드로 분리

### DIFF
--- a/app/games/models.py
+++ b/app/games/models.py
@@ -65,6 +65,30 @@ class Game(models.Model):
     def swap_turn(self):
         self.turn = "white" if self.turn == "black" else "black"
 
+    def get_player_name(self, color):
+        """색상에 해당하는 플레이어의 표시 이름 반환"""
+        player = self.black if color == "black" else self.white
+        return (player.first_name or player.username) if player else None
+
+    def get_both_player_names(self):
+        """양쪽 플레이어의 이름을 딕셔너리로 반환"""
+        return {
+            "black_player": self.get_player_name("black"),
+            "white_player": self.get_player_name("white"),
+        }
+
+    def reset_for_new_round(self):
+        """새 라운드를 위해 게임판, 타이머, 턴을 초기화"""
+        self.board = "." * (BOARD_SIZE * BOARD_SIZE)
+        self.turn = "black"
+        self.black_time_remaining = 900
+        self.white_time_remaining = 900
+        self.last_move_time = None
+
+    def clear_moves(self):
+        """게임의 모든 수를 삭제"""
+        self.moves.all().delete()
+
 
 class Move(models.Model):
     game = models.ForeignKey(Game, on_delete=models.CASCADE, related_name="moves")

--- a/app/games/views.py
+++ b/app/games/views.py
@@ -143,12 +143,8 @@ def join_game(request, pk):
         game.white = request.user
 
         # 백 플레이어가 입장하면 게임 초기화
-        # 1. 기존 수(Move) 모두 삭제
-        Move.objects.filter(game=game).delete()
-
-        # 2. 게임판 초기화
-        game.board = "." * (BOARD_SIZE * BOARD_SIZE)
-        game.turn = "black"  # 턴도 흑으로 리셋
+        game.clear_moves()
+        game.reset_for_new_round()
         game.save()
 
         # WebSocket으로 모든 클라이언트에게 플레이어 입장 알림


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 중복된 코드 유틸 함수와 헬퍼 메서드로 분리

## 📄 상세 내용
- [X] Game 모델에 헬퍼 메서드 추가
- [X] consumers.py :  중복 코드 제거
- [X] views.py : 게임 리셋 로직을 메서드로 교체 -> 코드의 의도가 좀 더 직관적

## 🎯 개선 효과
1. 코드 감소: 
- 플레이어 이름 가져오기 중복 16회 →메서드 호출로 통합
- GameHistory 생성 중복 5회 → 함수 호출로 통합
- 약 100줄 이상의 중복 코드 제거
2. 유지보수성 향상 : 
- 플레이어 이름 표시 로직 변경 시 1곳만 수정
- 전적 기록 로직 변경 시 1곳만 수정
- 게임 리셋 로직 변경 시 1곳만 수정
- 버그 발생 가능성 감소
3. 코드 가독성:
- 복잡한 로직이 명확한 메서드 이름으로 추상화됨
- game.get_both_player_names() -> 의도가 명확
- record_game_result(game) -> 기능이 명확
