### PR TITLE
[Feat/gomoku-game] 🐛 fix : 유저가 다른 페이지로 이동시 오프라인 상태 전환 수정

### DIFF
--- a/app/accounts/urls.py
+++ b/app/accounts/urls.py
@@ -4,6 +4,7 @@ from .views import (
     ProfileEditView,
     SignUpView,
     delete_account,
+    heartbeat,
     privacy_policy,
     terms_of_service,
     user_profile,
@@ -17,4 +18,5 @@ urlpatterns = [
     path("delete/", delete_account, name="delete_account"),  # 계정 삭제
     path("privacy-policy/", privacy_policy, name="privacy_policy"),  # 개인정보처리방침
     path("terms-of-service/", terms_of_service, name="terms_of_service"),  # 서비스 약관
+    path("heartbeat/", heartbeat, name="heartbeat"),  # 온라인 상태 갱신
 ]

--- a/config/settings.py
+++ b/config/settings.py
@@ -142,8 +142,22 @@ if REDIS_URL:
             "CONFIG": {"hosts": [REDIS_URL]},
         }
     }
+    # Redis 캐시 (온라인 유저 추적용)
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": REDIS_URL,
+        }
+    }
 else:
     CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+    # 로컬 메모리 캐시 (개발용)
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-snowflake",
+        }
+    }
 
 # ──────────────────────────────────────────────────────────────────────
 # 인증/국제화

--- a/templates/account/base_auth.html
+++ b/templates/account/base_auth.html
@@ -96,5 +96,6 @@
     </script>
     {% block content %}{% endblock %}
   </main>
+{% include "includes/heartbeat.html" %}
 </body>
 </html>

--- a/templates/account/profile.html
+++ b/templates/account/profile.html
@@ -314,5 +314,6 @@
       {% endif %}
     </div>
   </div>
+{% include "includes/heartbeat.html" %}
 </body>
 </html>

--- a/templates/games/friends.html
+++ b/templates/games/friends.html
@@ -409,5 +409,6 @@
       }
     });
   </script>
+{% include "includes/heartbeat.html" %}
 </body>
 </html>

--- a/templates/games/history.html
+++ b/templates/games/history.html
@@ -409,5 +409,6 @@
       </div>
     </div>
   </div>
+{% include "includes/heartbeat.html" %}
 </body>
 </html>

--- a/templates/games/lobby.html
+++ b/templates/games/lobby.html
@@ -1959,5 +1959,7 @@
     </div>
     <p style="margin: 0; color: #666; font-size: 0.85rem;">© 2026 오목조목. All rights reserved.</p>
   </footer>
+
+{% include "includes/heartbeat.html" %}
 </body>
 </html>

--- a/templates/includes/heartbeat.html
+++ b/templates/includes/heartbeat.html
@@ -1,0 +1,39 @@
+<!-- 온라인 상태 하트비트 스크립트 -->
+<script>
+(function() {
+  // 로그인한 사용자만 하트비트 전송
+  {% if user.is_authenticated %}
+  const HEARTBEAT_INTERVAL = 30000; // 30초
+  const HEARTBEAT_URL = '{% url "accounts:heartbeat" %}';
+  const CSRF_TOKEN = '{{ csrf_token }}';
+
+  function sendHeartbeat() {
+    fetch(HEARTBEAT_URL, {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': CSRF_TOKEN,
+        'Content-Type': 'application/json',
+      },
+      credentials: 'same-origin'
+    }).catch(err => {
+      // 네트워크 오류 시 무시 (다음 하트비트에서 재시도)
+      console.debug('Heartbeat failed:', err);
+    });
+  }
+
+  // 페이지 로드 시 즉시 하트비트 전송
+  sendHeartbeat();
+
+  // 30초마다 하트비트 전송
+  setInterval(sendHeartbeat, HEARTBEAT_INTERVAL);
+
+  // 페이지 이탈 시에도 하트비트 전송 시도 (선택적)
+  window.addEventListener('beforeunload', function() {
+    // navigator.sendBeacon을 사용하면 페이지 이탈 시에도 전송 가능
+    const formData = new FormData();
+    formData.append('csrfmiddlewaretoken', CSRF_TOKEN);
+    navigator.sendBeacon(HEARTBEAT_URL, formData);
+  });
+  {% endif %}
+})();
+</script>


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 유저가 다른 페이지로 이동시 오프라인 상태 전환 수정, 방장이 오프라인이면 방을 삭제하도록 수정

## 📄 상세 내용
- [X] settings.py : 캐시 설정 추가
- [X] accounts/views.py : 하트비트 API 추가 (POST /accounts/heartbeat/ -> 30초마다 호출 -> 60초 내 활동 있으면 온라인으로 표시)
- [X] consumers.py : get_online_users() 수정 -> 하트비트 캐시 + 로비 WebSocket + 게임 중인 유저 - 3가지 소스로 온라인 유저 조회
- [X] 각 방의 방장이 온라인인지 확인 (하트비트 캐시) -> 오프라인인 빈방이면 자동 삭제, 온라인이면 해당 방 유지 
- [X] 하트비트 JS 스크립트 추가

동작 방식:                                                                                                                                                 
  - 로그인한 유저가 어느 페이지에 있든 30초마다 서버에 하트비트 전송                                                                                         
  - 60초 내 하트비트가 있으면 로비 접속자 목록에 온라인으로 표시                                                                                             
  - 친구 목록, 프로필 수정 페이지 등에서도 온라인 상태 유지
