### PR TITLE
[Feat/mobile] 🐛 fix : 모바일 UI 개선

### DIFF
--- a/templates/games/history.html
+++ b/templates/games/history.html
@@ -243,13 +243,14 @@
 
       .header {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         gap: 12px;
         padding: 16px;
       }
 
       .header h1 {
         font-size: 22px;
+        text-align: center;
       }
 
       .btn {
@@ -320,6 +321,25 @@
 
       .empty-state::before {
         font-size: 48px;
+      }
+
+      /* 페이지네이션 모바일 */
+      .pagination {
+        gap: 4px;
+        flex-wrap: nowrap;
+      }
+
+      .pagination a,
+      .pagination span {
+        min-width: auto;
+        height: 36px;
+        padding: 0 8px;
+        font-size: 12px;
+      }
+
+      .pagination .page-info {
+        font-size: 11px;
+        margin: 0 4px;
       }
     }
 

--- a/templates/games/lobby.html
+++ b/templates/games/lobby.html
@@ -918,20 +918,21 @@
 
       .header {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         gap: 12px;
         padding: 16px;
       }
 
       .header h1 {
         font-size: 22px;
+        text-align: center;
       }
 
       .top-actions {
         width: 100%;
         display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 10px;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 8px;
       }
 
       .user-info {
@@ -947,15 +948,17 @@
       .top-actions .btn {
         text-align: center;
         white-space: nowrap;
-        min-height: 44px;
+        min-height: 40px;
         display: flex;
         align-items: center;
         justify-content: center;
+        font-size: 12px !important;
+        padding: 6px 8px !important;
       }
 
       .logout-btn {
         background: #c44 !important;
-        min-height: 44px;
+        min-height: 40px;
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #185 
- 작업 요약: 내 전적, 로비 모바일 UI 개선 

## 📄 상세 내용
- [X] 타이틀 "오목조목 로비" 중앙 정렬 & 타이틀 "게임 전적" 중앙 정렬
- [X] 버튼 레이아웃을 2열 → 3열 그리드로 변경
- [X] 페이지네이션 모바일 스타일 추가
